### PR TITLE
Do not allow insecure auth in production

### DIFF
--- a/articles/active-directory-b2c/add-api-connector.md
+++ b/articles/active-directory-b2c/add-api-connector.md
@@ -483,7 +483,7 @@ After you deploy your REST API, set the metadata of the `REST-ValidateProfile` t
 - **ServiceUrl**. Set the URL of the REST API endpoint.
 - **SendClaimsIn**. Specify how the input claims are sent to the RESTful claims provider.
 - **AuthenticationType**. Set the type of authentication being performed by the RESTful claims provider. 
-- **AllowInsecureAuthInProduction**. In a production environment, make sure to set this metadata to `true`
+- **AllowInsecureAuthInProduction**. In a production environment, make sure to set this metadata to `false`
 	
 See the [RESTful technical profile metadata](restful-technical-profile.md#metadata) for more configurations.
 


### PR DESCRIPTION
To be completely honest I am not 100% sure on this, but it seems odd to me that I should make sure to enable insecure auth in a production environment.
If this is not a typo but the actual recommendation feel free to reject.